### PR TITLE
Use color-scheme for dark mode

### DIFF
--- a/_static/style.css
+++ b/_static/style.css
@@ -7,6 +7,16 @@ img.sidebar-logo { max-width: 55%; } /* Smaller logo */
 figcaption p { font-style: italic; }
 .admonition p { font-size: 1rem; }
 .admonition li { font-size: 1rem; }
+@media not print {
+    body[data-theme="dark"] {
+      color-scheme: dark;
+    }
+    @media (prefers-color-scheme: dark) {
+      body:not([data-theme="light"]) {
+        color-scheme: dark;
+      }
+    }
+}
 /* END THEME:FUGO SPECIFIC */
 
 


### PR DESCRIPTION

Adds css rule `color-scheme: dark;` when using dark mode.

This takes browser style defaults for dark mode into place. Most notably for the book the scrollbar becomes dark.

From             |  To
:-------------------------:|:-------------------------:
![Näyttökuva 2024-03-05 002344](https://github.com/chrokh/the-oo-way/assets/39066923/39fe7c30-5e60-4930-be42-0de60b08e300)  |  ![Näyttökuva 2024-03-05 002334](https://github.com/chrokh/the-oo-way/assets/39066923/558cc966-5761-4c2f-9cf1-cb7702428f01)

NOTE: I did not build the book, but as far as I can see this file would be imported as is to the production site so the change should be good to go.

I did test the change in developer tools, though.